### PR TITLE
commented out animation for splash logo image

### DIFF
--- a/frontend/src/scss/splash.scss
+++ b/frontend/src/scss/splash.scss
@@ -17,6 +17,10 @@
         opacity: 0;
     }
 
+    40%{
+        opacity: 0;
+    }
+
     100%{
         opacity: 100%;
     }
@@ -35,8 +39,8 @@
     
     margin-right: 50px;
     height:250px;
-    -webkit-animation: FadeIn 2s;
-    animation: FadeIn 2s;
+    // -webkit-animation: FadeIn 2s;
+    // animation: FadeIn 2s;
 }
 
 #logo-text{


### PR DESCRIPTION
temporarily disabling fade-in animation until we can figure out why it's not working on heroku