### PR TITLE
Add/admin page info skeleton

### DIFF
--- a/frontend/src/components/admin/Admin.jsx
+++ b/frontend/src/components/admin/Admin.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function Admin() {
   // admin page should include access to reservations made by elders and availability set by volunteers
   // when clicking on a volunteers, should be able to see calendar highlighted with availability
@@ -6,7 +8,19 @@ function Admin() {
   // elder/volunteer cards should have all relative details on them, or at least name and contact info
   return (
     <>
-    {/* header for admin page, if admin has id, then have Hello 'id' in the top right corner */}
+      <h1>Admin Page</h1>
+      <h6></h6>
+      <br/>
+      <div>
+        <details className="admin volunteer-details">
+          <summary>Volunteers</summary>
+          <p>This section is dedicated to showing availability for volunteers.</p>
+        </details>
+        <details className="admin request-details">
+          <summary>Requests</summary>
+          <p>This section is dedicated to showing community member's requests for chaperones.</p>
+        </details>
+      </div>
     {/* have page split with top half split left and right calendars, bottom section should be platform to contact both elder and volunteer matched with each other */}
     </>
   )

--- a/frontend/src/components/admin/Admin.jsx
+++ b/frontend/src/components/admin/Admin.jsx
@@ -13,17 +13,25 @@ class Admin extends React.Component {
 
     return (
       <>
-        <h1>Admin Page</h1>
-        <h6>Admins can use this page to access data on volunteers and community members who made requests.</h6>
+        <header className="admin header">
+          <h1 >Admin Dashboard</h1>
+          <h6>Admins can use this page to access data on volunteers and community members who made requests.</h6>
+        </header>
         <br/>
-        <div>
+        <div className="admin details">
           <details className="admin volunteer-details">
-            <summary>Volunteers</summary>
+            <summary>Volunteer Links</summary>
             <p>This section is dedicated to showing availability for volunteers.</p>
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/16OVaMO13jzIIRy4ujCNsM-6xZUj8CNv9jCJWC72J9fo/edit?usp=sharing">Volunteer Google Form Access</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/spreadsheets/d/1TZRyWaXMZMJ-ebZsr6niFVJoNfK-h9QgTobCbPV_Bbc/edit?usp=sharing">Volunteer Google Sheets Access</a>
           </details>
           <details className="admin request-details">
-            <summary>Requests</summary>
+            <summary>Request Links</summary>
             <p>This section is dedicated to showing community member's requests for chaperones.</p>
+
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/1b-R4tvuUAVNaL5uLsq6UNjl_nuynJ_z5xVSYepHiv9E/edit?usp=sharing">Request Google Form Access</a>
+            
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/spreadsheets/d/1TZRyWaXMZMJ-ebZsr6niFVJoNfK-h9QgTobCbPV_Bbc/edit?usp=sharing">Request Google Sheets Access</a>
           </details>
         </div>
       {/* have page split with top half split left and right calendars, bottom section should be platform to contact both elder and volunteer matched with each other */}

--- a/frontend/src/components/admin/Admin.jsx
+++ b/frontend/src/components/admin/Admin.jsx
@@ -1,29 +1,35 @@
 import React from 'react';
 
-function Admin() {
+class Admin extends React.Component {
+  constructor(props) {
+    super(props);
+  }
   // admin page should include access to reservations made by elders and availability set by volunteers
   // when clicking on a volunteers, should be able to see calendar highlighted with availability
   // when clicking on an elder, should be able to see calendar highlighted with requested date/time
   //include a sort option by date/time
   // elder/volunteer cards should have all relative details on them, or at least name and contact info
-  return (
-    <>
-      <h1>Admin Page</h1>
-      <h6></h6>
-      <br/>
-      <div>
-        <details className="admin volunteer-details">
-          <summary>Volunteers</summary>
-          <p>This section is dedicated to showing availability for volunteers.</p>
-        </details>
-        <details className="admin request-details">
-          <summary>Requests</summary>
-          <p>This section is dedicated to showing community member's requests for chaperones.</p>
-        </details>
-      </div>
-    {/* have page split with top half split left and right calendars, bottom section should be platform to contact both elder and volunteer matched with each other */}
-    </>
-  )
+  render() {
+
+    return (
+      <>
+        <h1>Admin Page</h1>
+        <h6>Admins can use this page to access data on volunteers and community members who made requests.</h6>
+        <br/>
+        <div>
+          <details className="admin volunteer-details">
+            <summary>Volunteers</summary>
+            <p>This section is dedicated to showing availability for volunteers.</p>
+          </details>
+          <details className="admin request-details">
+            <summary>Requests</summary>
+            <p>This section is dedicated to showing community member's requests for chaperones.</p>
+          </details>
+        </div>
+      {/* have page split with top half split left and right calendars, bottom section should be platform to contact both elder and volunteer matched with each other */}
+      </>
+    )
+  }
 }
 
 export default Admin;

--- a/frontend/src/components/admin/admin_container.js
+++ b/frontend/src/components/admin/admin_container.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import Admin from './Admin';
+
+const msp = (state) => {
+  return {}
+}
+
+const mdp = (dispatch) => {
+  return {}
+}
+
+export default connect(msp, mdp)(Admin);

--- a/frontend/src/components/app.jsx
+++ b/frontend/src/components/app.jsx
@@ -4,6 +4,7 @@ import { Route, Switch } from 'react-router-dom';
 import Navbar from './navbar/navbar';
 import Splash from './splash/splash';
 import About from './about/about';
+import AdminContainer from './admin/admin_container';
 import Protection from './protection/protection';
 import Volunteers from './volunteers/volunteers';
 import VolunteerForm from './forms/volunteer_form';
@@ -23,6 +24,7 @@ const App = () => (
                 <Route exact path="/volunteers/signup" component={VolunteerForm} />
                 <Route exact path="/feedback" component={Feedback} />
                 <AuthRoute exact path="/login" component={Login} />
+                <ProtectedRoute exact path="/admin" component={AdminContainer} />
             </Switch>
 
             

--- a/frontend/src/scss/admin.scss
+++ b/frontend/src/scss/admin.scss
@@ -1,0 +1,47 @@
+header {
+  display: flex;
+  flex-direction: column;
+}
+
+h1, h6 {
+  color: $logo-blue;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.admin.details {
+  width: 100%;
+  height: 50%;
+
+  details {
+    width: 50%;
+    height: 100%;
+  }
+
+  summary {
+    font-size: 25px;
+  }
+
+  .volunteer-details, .request-details {
+    display: flex;
+    flex-direction: column;
+
+    color: $poe-blue;
+    margin: auto;
+    padding: 50px;
+    p {
+      margin: 15px 0;
+    }
+    a {
+      margin: 10px 0;
+      width: fit-content;
+      border: 1px solid $poe-blue;
+      border-radius: 5px;
+      background-color: $poe-blue;
+      padding: 15px;
+      text-decoration: none;
+      color: white;
+    }
+  }
+  
+}

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -29,3 +29,4 @@ $logo-blue: #003d5b;
 @import './footer.scss';
 @import './get_involved.scss';
 @import './login.scss';
+@import './admin.scss';


### PR DESCRIPTION
- Filled out `Admin` landing page to include a header and a two details with summaries and links for the currently used google forms and sheets
- included frontend route for `AdminContainer`, container will be used to add state to `Admin` in a future push
- added `admin.scss` file for styling, subject to change at any point


