### PR TITLE
Hotfix/redirect to admin after login

### DIFF
--- a/frontend/src/components/session/Login.jsx
+++ b/frontend/src/components/session/Login.jsx
@@ -25,6 +25,7 @@ class LoginForm extends React.Component {
         }
         //  
         this.props.login(user);
+        this.props.history.push('/admin');
     }
 
     guestLoginUpdate(key, value){

--- a/frontend/src/components/session/Login.jsx
+++ b/frontend/src/components/session/Login.jsx
@@ -24,8 +24,8 @@ class LoginForm extends React.Component {
             password: this.state.password,
         }
         //  
-        this.props.login(user);
-        this.props.history.push('/admin');
+        this.props.login(user)
+            .then(() => this.props.history.push('/admin'));
     }
 
     guestLoginUpdate(key, value){


### PR DESCRIPTION
Changed Login component's handleSubmit to redirect to admin:
```
this.props.login(user)
            .then(() => this.props.history.push('/admin'));
```